### PR TITLE
Add stop workers and update quiet/wake scripts following EBv3 and amazonlinux2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.aws-sam/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,32 @@ The pieces which run in AWS are managed via Cloudformation.  Create a stack usin
 * SlackWebhook - the full URL of a Slack incoming webhook 
 * SlackChannel - the name of the Slack channel to send notifications to
 
+You may also build and deploy using AWS SAM (tested with SAM CLI, version 1.22.0):
+
+## Build
+
+```shell
+sam build --use-container --debug --template cfn/snow-white-cfn.yml
+```
+
+## Deploy
+
+```shell
+sam deploy --debug --stack-name snow-white \
+  --s3-bucket deploy-bucket \
+  --region us-east-1 \
+  --template cfn/snow-white-cfn.yml \
+  --profile staging \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --no-fail-on-empty-changeset \
+  --parameter-overrides "SlackChannel=#snow_white_messages \
+                        SlackWebhook=https://hooks.slack.com/services/ABC/123 \
+                        CfnQuietDocName=QuietSideKiqDocument \
+                        CfnWakeDocName=WakeSideKiqDocument \
+                        CfnStopDocName=StopSideKiqDocument \
+                        CfnStackName=snow-white"
+```
+
 # Helper script Configuration (snow-white.sh)
 A small helper script is provided (syntax below) to invoke the Snow White fargate task.  Before running for the first time, you will need to set a few variables at the top of the script:
 
@@ -42,7 +68,7 @@ A small helper script is provided (syntax below) to invoke the Snow White fargat
 # Usage
 Clone this repo and run the snow-white.sh helper script.
 
-`usage: usage: snow-white -a quiet|wake -e <EB env name pattern> -f staging|production  -p <EB app name> -r <region>`
+`usage: usage: snow-white -a quiet|wake|stop -e <EB env name pattern> -f staging|production  -p <EB app name> -r <region>`
 
 Where:
 * -a designates if we are quieting or waking the workers

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To obtain the Slack userID, visit Slack in a browser, view a user's profile and 
 
 # Elastic Beanstalk Configuration
 Instances that you wish to use Snow White with must be running under a role that allows the SSM agent to run.  Generally, just attach the managed policy `AmazonEC2RoleForSSM` to the role to grant the required permissions.
+Snow White was tested on Elasticbeanstalk v3 which uses EC2 instances running amazon linux 2, systemd and a single sidekiq service.  Note that original implementation used Elasticbeanstalk v2, upstart and 2 sidekiq processes.
 
 # AWS Installation
 The pieces which run in AWS are managed via Cloudformation.  Create a stack using the template in the `cfn` folder.  It takes 4 parameters:
@@ -51,7 +52,7 @@ Where:
 * -f is the AWS profile to use
 
 Example:
-`./snowwhite.sh -a quiet -e workers -p MY-EB-APP -r us-east-1 -f staging`
+`./snow-white.sh -a quiet -e workers -p MY-EB-APP -r us-east-1 -f staging`
 
 This will submit a task to AWS Fargate which will in turn run an AWS SSM command on each instance of all Sidekiq workers in the EB application whose environment names contain the string `workers`.  The Fargate task will then monitor each worker until the queue is drained and will report back via Slack
 

--- a/cfn/snow-white-cfn.yml
+++ b/cfn/snow-white-cfn.yml
@@ -17,6 +17,9 @@ Parameters:
   CfnWakeDocName:
     Type: String
     Default: "WakeSideKiqDocument"
+  CfnStopDocName:
+    Type: String
+    Default: "StopSideKiqDocument"
 
 Resources:
   LogGroup:
@@ -61,6 +64,9 @@ Resources:
             - 
               Name: "WAKE_COMMAND_LOGICAL_NAME"
               Value: !Ref CfnWakeDocName
+            - 
+              Name: "STOP_COMMAND_LOGICAL_NAME"
+              Value: !Ref CfnStopDocName
             -
               Name: "EB_ENV_NAME_PATTERN_STRING"
               Value: "workers"

--- a/cfn/snow-white-cfn.yml
+++ b/cfn/snow-white-cfn.yml
@@ -151,6 +151,42 @@ Resources:
             - "/tmp/quiet_sidekiq_workers.sh"
             workingDirectory: "/tmp"
             timeoutSeconds: "{{ executionTimeout }}"
+  StopSideKiqDocument:
+    Type: AWS::SSM::Document
+    Properties:
+      DocumentType: Command
+      Content: 
+        schemaVersion: "2.2"
+        description: "Stop Sidekiq Workers"
+        parameters:
+          executionTimeout:
+            type: "String"
+            default: "7200"
+            description: "(Optional) The time in seconds for a command to be completed before\
+              \ it is considered to have failed. Default is 3600 (1 hour). Maximum is 172800\
+              \ (48 hours)."
+            allowedPattern: "([1-9][0-9]{0,4})|(1[0-6][0-9]{4})|(17[0-1][0-9]{3})|(172[0-7][0-9]{2})|(172800)"
+        mainSteps:
+        -
+          action: "aws:downloadContent"
+          name: "downloadScripts"
+          inputs:
+            sourceType: "GitHub"
+            sourceInfo: "{ \"owner\":\"rewindio\", \"repository\": \"snow-white\", \"path\"\ : \"ssm/stop_sidekiq_workers.sh\" }"
+            destinationPath: "/tmp"
+        - precondition:
+            StringEquals:
+            - "platformType"
+            - "Linux"
+          action: "aws:runShellScript"
+          name: "stop_workers"
+          inputs:
+            runCommand:
+            - "ls -l"
+            - "chmod a+x /tmp/stop_sidekiq_workers.sh"
+            - "/tmp/stop_sidekiq_workers.sh"
+            workingDirectory: "/tmp"
+            timeoutSeconds: "{{ executionTimeout }}"
 
   WakeSideKiqDocument:
     Type: AWS::SSM::Document

--- a/container-src/snow-white.py
+++ b/container-src/snow-white.py
@@ -247,6 +247,12 @@ if 'WAKE_COMMAND_LOGICAL_NAME' not in os.environ:
 else:
     wake_command_logical_name = os.environ['WAKE_COMMAND_LOGICAL_NAME']
 
+if 'STOP_COMMAND_LOGICAL_NAME' not in os.environ:
+    print("Error: STOP_COMMAND_LOGICAL_NAME environment variable must be set")
+    exit(-1)
+else:
+    stop_command_logical_name = os.environ['STOP_COMMAND_LOGICAL_NAME']
+
 if 'CFN_STACK_NAME' not in os.environ:
     print("Error: CFN_STACK_NAME environment variable must be set")
     exit(-1)
@@ -321,7 +327,15 @@ else:
         if quiet_command_doc:
             command_id = submit_ssm_command(instances_for_command, quiet_command_doc, ssm_client)
         else:
-            print("Error occured getting the quiet command doc name")
+            print("Error occurred getting the quiet command doc name")
+    elif worker_action == "stop":
+        print("Running the STOP command on the workers")
+        stop_command_doc = get_ssm_doc_name(cfn_stack_name, stop_command_logical_name, cfn_client)
+
+        if stop_command_doc:
+            command_id = submit_ssm_command(instances_for_command, stop_command_doc, ssm_client)
+        else:
+            print("Error occurred getting the stop command doc name")
     elif worker_action == "wake":
         print("Running the WAKE command on the workers")
 
@@ -330,7 +344,7 @@ else:
         if wake_command_doc:
             command_id = submit_ssm_command(instances_for_command, wake_command_doc, ssm_client)
         else:
-            print("Error occured getting the wake command doc name")
+            print("Error occurred getting the wake command doc name")
 
     time.sleep(2)  # https://stackoverflow.com/questions/50067035/retrieving-command-invocation-in-aws-ssm
 
@@ -411,6 +425,8 @@ else:
             slack_string = "The workers are all quiet for all environment names containing _" + eb_env_name_pattern_string + "_ in *" + eb_app_name + " (" + aws_region + ")*"
         elif worker_action == "wake":
             slack_string = "The workers are all awake for all environment names containing _" + eb_env_name_pattern_string + "_ in *" + eb_app_name + " (" + aws_region + ")*"
+        elif worker_action == "stop":
+            slack_string = "The workers are all stopped for all environment names containing _" + eb_env_name_pattern_string + "_ in *" + eb_app_name + " (" + aws_region + ")*"
 
     # Post some messages to Slack
     if send_to_slack_user:

--- a/snow-white.sh
+++ b/snow-white.sh
@@ -9,7 +9,7 @@ sec_group=YOUR SECURITY GROUP ID
 
 
 show_help() {
-    echo "usage: snow-white -a quiet|wake -e <EB env name pattern> -f staging|production  -p <EB app name> -r <region>"
+    echo "usage: snow-white -a quiet|wake|stop -e <EB env name pattern> -f staging|production  -p <EB app name> -r <region>"
 }
 
 #
@@ -40,7 +40,7 @@ if [ -z "${profile}" ] || [ -z "${ebapp}" ] || [ -z "${action}" ] || [ -z "${reg
     show_help
     exit 1
 else
-    if [ "${action}" != "quiet" ] && [ "${action}" != "wake" ]; then
+    if [ "${action}" != "quiet" ] && [ "${action}" != "wake" ] && [ "${action}" != "stop" ]; then
         show_help
         exit 1
     fi

--- a/ssm/quiet_sidekiq_workers.sh
+++ b/ssm/quiet_sidekiq_workers.sh
@@ -19,8 +19,11 @@ get_running_count() {
 }
 
 #quiets a worker
+# input: 17774 sidekiq 5.2.3 current [0 of 10 busy]
 quiet_worker() {
-    systemctl kill -s TSTP sidekiq
+    local __workerinfo=$1
+    PID=$(get_pid $__workerinfo)
+    kill -TSTP ${PID}
 }
 
 # Checks to see if the worker is in the stopping state
@@ -47,7 +50,7 @@ do
     echo  "Quieting worker ${worker}"
 
     # Quiet the worker
-    quiet_worker
+    quiet_worker "${worker}"
 done
 unset IFS
 

--- a/ssm/quiet_sidekiq_workers.sh
+++ b/ssm/quiet_sidekiq_workers.sh
@@ -39,7 +39,7 @@ is_worker_stopping() {
 # MAINLINE
 # 
 
-sidekiq_workers=$(pgrep -lf ^sidekiq)
+sidekiq_workers=$(pgrep -lfa ^sidekiq)
 worker_count=0
 
 IFS=$'\n'
@@ -60,8 +60,8 @@ unset IFS
 # has a timeout
 while :
 do
-    sidekiq_workers=$(pgrep -lf ^sidekiq) # Re-get the list of workers
-    worker_count=$(pgrep -lf ^sidekiq | wc -l)
+    sidekiq_workers=$(pgrep -lfa ^sidekiq) # Re-get the list of workers
+    worker_count=$(pgrep -lfa ^sidekiq | wc -l)
     workers_idle=0
 
     echo "There are ${worker_count} workers running"

--- a/ssm/quiet_sidekiq_workers.sh
+++ b/ssm/quiet_sidekiq_workers.sh
@@ -19,12 +19,8 @@ get_running_count() {
 }
 
 #quiets a worker
-# input: 17774 sidekiq 5.2.3 current [0 of 10 busy]
 quiet_worker() {
-    local __workerinfo=$1
-    PID=$(get_pid $__workerinfo)
-
-    kill -TSTP ${PID}
+    systemctl kill -s TSTP sidekiq
 }
 
 # Checks to see if the worker is in the stopping state
@@ -51,7 +47,7 @@ do
     echo  "Quieting worker ${worker}"
 
     # Quiet the worker
-    quiet_worker "${worker}"
+    quiet_worker
 done
 unset IFS
 

--- a/ssm/stop_sidekiq_workers.sh
+++ b/ssm/stop_sidekiq_workers.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+echo "Stopping the Sidekiq workers"
+
+REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
+
+# Returns the PID of the worker process
+get_pid() {
+    local __workerinfo=$1
+    pid=$(echo ${__workerinfo} | cut -f 1 -d' ')
+    echo ${pid}
+}
+
+# Returns the number of currently running jobs
+get_running_count() {
+    local __workerinfo=$1
+    count=$(echo ${__workerinfo} | cut -f 5 -d' ' | cut -f2 -d [)
+    echo ${count}
+}
+
+# Checks to see if the worker is in the stopping state
+is_worker_stopping() {
+    local __workerinfo=$1
+    stopping=$(echo ${__workerinfo} | cut -f 9 -d' ')
+
+    echo "${stopping}"
+}
+#stops a worker gracefully https://github.com/mperham/sidekiq/wiki/Signals#term
+term_sidekiq() {
+    systemctl kill -s TERM sidekiq
+    echo $?
+}
+
+# Checks to see if the worker is in the stopping state
+sidekiq_running() {
+    systemctl is-active --quiet sidekiq
+    echo $?
+}
+
+#
+# MAINLINE
+#
+
+if [[ "$(sidekiq_running)" -eq "0" ]]; then
+    echo "Sidekiq is running.  Send it a TERM signal to gracefully shut it down"
+    term_sidekiq
+    sleep 5
+else
+    echo "Sidekiq is already shutdown"
+fi
+
+# Now we can poll the workers to see if they are finished their work
+# This can be an infinite loop with an exit because the EC2 run command
+# has a timeout
+while :; do
+    sidekiq_workers=$(pgrep -lfa ^sidekiq) # Re-get the list of workers
+    worker_count=$(pgrep -lfa ^sidekiq | wc -l)
+    workers_idle=0
+
+    echo "There are ${worker_count} workers running"
+
+    IFS=$'\n'
+    for worker in ${sidekiq_workers}; do
+        worker_pid=$(get_pid ${worker})
+        echo "Checking to see if worker ${worker_pid} has completed all jobs"
+
+        if [ "$(is_worker_stopping "${worker}")" == "stopping" ]; then
+            echo "Worker ${worker_pid} is in a STOPPING state"
+        else
+            echo "Worker ${worker_pid} is not in a STOPPING state - did something go wrong with the quiet signal?"
+        fi
+
+        running_count=$(get_running_count ${worker})
+        echo "Worker ${worker_pid} is running ${running_count} jobs"
+
+        if [ ${running_count} -eq 0 ]; then
+            # This worker is all done
+            workers_idle=$((workers_idle + 1))
+            echo "There are ${workers_idle} workers now idle"
+        fi
+    done
+    unset IFS
+
+    if [ ${workers_idle} -eq ${worker_count} ]; then
+        # All workers are idle - bail from this loop
+        break
+    fi
+
+    sleep 10
+done
+
+echo "All workers are stopped"

--- a/ssm/wake_sidekiq_workers.sh
+++ b/ssm/wake_sidekiq_workers.sh
@@ -7,46 +7,58 @@ REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-
 # Returns the PID of the worker process
 get_pid() {
     local __workerinfo=$1
-    pid=$(echo ${__workerinfo} |cut -f 1 -d' ')
+    pid=$(echo ${__workerinfo} | cut -f 1 -d' ')
     echo ${pid}
 }
 
-# Wakes a worker (kill and let it be restarted)
+# Wakes up a worker by restarting the process
 wake_worker() {
-    local __workerinfo=$1
-    PID=$(get_pid $__workerinfo)
-    kill -TERM ${PID}
+    systemctl restart sidekiq
 }
 
 # Returns the number of currently running jobs
 get_running_count() {
     local __workerinfo=$1
-    count=$(echo ${__workerinfo} |cut -f 5 -d' ' |cut -f2 -d [)
+    count=$(echo ${__workerinfo} | cut -f 5 -d' ' | cut -f2 -d [)
     echo ${count}
 }
 
 # Checks to see if the worker is in the stopping state
 is_worker_stopping() {
     local __workerinfo=$1
-    stopping=$(echo ${__workerinfo} |cut -f 9 -d' ')
+    stopping=$(echo ${__workerinfo} | cut -f 9 -d' ')
 
     echo "${stopping}"
 }
 
+# Checks to see if the worker is in the stopping state
+sidekiq_running() {
+    systemctl is-active --quiet sidekiq
+    echo $?
+}
+
 #
 # MAINLINE
-# 
+#
 
+# If sidekiq was stopped, the wake script can also be used to start it up and be done
+if [[ "$(sidekiq_running)" -ne "0" ]]; then
+    echo "Sidekiq is not running.  Start it up"
+    wake_worker
+
+    exit 0
+fi
+
+# The wake script needs to restart quieted workers because systemctl does not auto-restart a TERM'ed sidekiq process
 sidekiq_workers=$(pgrep -lfa ^sidekiq)
 
 IFS=$'\n'
-for worker in ${sidekiq_workers}
-do
-    worker=$(echo ${worker}|tr -d '\n' |xargs)
-    echo  "Waking worker ${worker}"
+for worker in ${sidekiq_workers}; do
+    worker=$(echo ${worker} | tr -d '\n' | xargs)
+    echo "Waking worker ${worker}"
 
     # Make sure it's in the stopping state
-    # If not, this is an error condition as we were 
+    # If not, this is an error condition as we were
     # called on a non-quieted worker
     if [ "$(is_worker_stopping "${worker}")" != "stopping" ]; then
         echo "Worker ${worker_pid} is not in a STOPPING state.  Will not wake"
@@ -55,7 +67,7 @@ do
         echo "Worker ${worker_pid} is running ${running_count} jobs"
 
         if [ ${running_count} -eq 0 ]; then
-            wake_worker "${worker}"
+            wake_worker
         else
             echo "Worker ${worker_pid} is still running ${running_count} - you cannot wake/restart this worker yet"
             exit 2

--- a/ssm/wake_sidekiq_workers.sh
+++ b/ssm/wake_sidekiq_workers.sh
@@ -37,7 +37,7 @@ is_worker_stopping() {
 # MAINLINE
 # 
 
-sidekiq_workers=$(pgrep -lf ^sidekiq)
+sidekiq_workers=$(pgrep -lfa ^sidekiq)
 
 IFS=$'\n'
 for worker in ${sidekiq_workers}


### PR DESCRIPTION
I want to use snow white to automate some tasks and it needed some updating:

Updating the quiet command as it was no longer working.

Before
```shell
[root@ip-10-11-7-191 bin]# pgrep -lf ^sidekiq
15950 bundle
```
After
```shell
[root@ip-10-11-7-191 bin]# pgrep -lfa ^sidekiq
15950 sidekiq 5.2.7 current [0 of 10 busy] stopping
```

The wake command used to work by sending a TERM signal and relying on upstart to revive the process.  EBv3 changed things to use systemd and the configuration does not auto-restart a stopped sidekiq process.  Solution here is to use systemctl and just restart.

Also making the wake script handle the case of starting completely stopped processes


Testing with scripts in /tmp.
The stop script was tested with a long running job and it waited and returned it to the queue as expected.

```
bash stop_sidekiq_workers.sh
Stopping the Sidekiq workers
Sidekiq is running.  Send it a TERM signal to gracefully shut it down
0
There are 1 workers running
Checking to see if worker 21038 has completed all jobs
Worker 21038 is in a STOPPING state
Worker 21038 is running 1 jobs
There are 1 workers running
Checking to see if worker 21038 has completed all jobs
Worker 21038 is in a STOPPING state
Worker 21038 is running 1 jobs
There are 0 workers running
All workers are stopped
```

```
bash wake_sidekiq_workers.sh
Waking the Sidekiq workers
Sidekiq is not running.  Start it up

pgrep -lfa ^sidekiq
21634 sidekiq 5.2.7 current [1 of 10 busy]
```

Quieting with LRJ continues to wait until the job completes on its own.
```
 bash quiet_sidekiq_workers.sh
Quieting the Sidekiq workers
Quieting worker 21634 sidekiq 5.2.7 current [1 of 10 busy]
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is not in a STOPPING state - did something go wrong with the quiet signal?
Worker 21634 is running 1 jobs
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is in a STOPPING state
Worker 21634 is running 1 jobs
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is in a STOPPING state
Worker 21634 is running 1 jobs
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is in a STOPPING state
Worker 21634 is running 1 jobs
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is in a STOPPING state
Worker 21634 is running 1 jobs
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is in a STOPPING state
Worker 21634 is running 1 jobs
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is in a STOPPING state
Worker 21634 is running 1 jobs
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is in a STOPPING state
Worker 21634 is running 1 jobs
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is in a STOPPING state
Worker 21634 is running 1 jobs
There are 1 workers running
Checking to see if worker 21634 has completed all jobs
Worker 21634 is in a STOPPING state
Worker 21634 is running 0 jobs
There are 1 workers now idle
All workers are quiet



pgrep -lfa ^sidekiq
21634 sidekiq 5.2.7 current [0 of 10 busy] stopping
```

